### PR TITLE
youtubeを開くと警告を表示

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,0 +1,1 @@
+window.alert('YouTube見るつもりか!?');

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,16 @@
+{
+    "name": "Sample",
+    "version": "1.0.0",
+    "manifest_version": 3,
+    "description": "Sample Chrome Extension",
+    "content_scripts": [
+        {
+            "matches": [
+                "https://www.youtube.com/*"
+            ],
+            "js": [
+                "content.js"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
#やったこと
- chrome拡張の実装のテスト
- youtubeを開いた時に警告を表示する
![スクリーンショット 2023-09-25 8 59 08](https://github.com/YuugouOhno/youtube-jammer/assets/105062512/35781834-39c7-4f1d-9bba-961a20f2f3ee)
